### PR TITLE
Automatically use google apps domain users for ssh

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
@@ -143,7 +143,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
           }
         }
       }
-      if (useDomainUsersForSsh) {
+      if (useDomainUsersForSsh && !email.isJsonNull()) {
         login = email.getAsString().split("@")[0];
       }
       return new OAuthUserInfo(id.getAsString() /*externalId*/,

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
@@ -63,6 +63,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
   private final String canonicalWebUrl;
   private final boolean linkToExistingOpenIDAccounts;
   private final String domain;
+  private final boolean useDomainUsersForSsh;
 
   @Inject
   GoogleOAuthService(PluginConfigFactory cfgFactory,
@@ -75,6 +76,8 @@ class GoogleOAuthService implements OAuthServiceProvider {
     this.linkToExistingOpenIDAccounts = cfg.getBoolean(
         InitOAuth.LINK_TO_EXISTING_OPENID_ACCOUNT, false);
     this.domain = cfg.getString(InitOAuth.DOMAIN);
+    this.useDomainUsersForSsh = cfg.getBoolean(
+        InitOAuth.USE_DOMAIN_USERS_FOR_SSH, false);
     String scope = linkToExistingOpenIDAccounts
         ? "openid " + SCOPE
         : SCOPE;
@@ -91,6 +94,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
       log.debug("OAuth2: linkToExistingOpenIDAccounts={}",
           linkToExistingOpenIDAccounts);
       log.debug("OAuth2: domain={}", domain);
+      log.debug("OAuth2: useDomainUsersForSsh={}", useDomainUsersForSsh);
     }
   }
 
@@ -121,6 +125,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
       JsonElement email = jsonObject.get("email");
       JsonElement name = jsonObject.get("name");
       String claimedIdentifier = null;
+      String login = null;
 
       if (linkToExistingOpenIDAccounts
           || !Strings.isNullOrEmpty(domain)) {
@@ -138,8 +143,11 @@ class GoogleOAuthService implements OAuthServiceProvider {
           }
         }
       }
+      if (useDomainUsersForSsh) {
+        login = email.getAsString().split("@")[0];
+      }
       return new OAuthUserInfo(id.getAsString() /*externalId*/,
-          null /*username*/,
+          login /*username*/,
           email == null || email.isJsonNull() ? null : email.getAsString() /*email*/,
           name == null || name.isJsonNull() ? null : name.getAsString() /*displayName*/,
 	      claimedIdentifier /*claimedIdentity*/);

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/GoogleOAuthService.java
@@ -63,7 +63,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
   private final String canonicalWebUrl;
   private final boolean linkToExistingOpenIDAccounts;
   private final String domain;
-  private final boolean useDomainUsersForSsh;
+  private final boolean useEmailAsUsername;
 
   @Inject
   GoogleOAuthService(PluginConfigFactory cfgFactory,
@@ -76,8 +76,8 @@ class GoogleOAuthService implements OAuthServiceProvider {
     this.linkToExistingOpenIDAccounts = cfg.getBoolean(
         InitOAuth.LINK_TO_EXISTING_OPENID_ACCOUNT, false);
     this.domain = cfg.getString(InitOAuth.DOMAIN);
-    this.useDomainUsersForSsh = cfg.getBoolean(
-        InitOAuth.USE_DOMAIN_USERS_FOR_SSH, false);
+    this.useEmailAsUsername = cfg.getBoolean(
+        InitOAuth.USE_EMAIL_AS_USERNAME, false);
     String scope = linkToExistingOpenIDAccounts
         ? "openid " + SCOPE
         : SCOPE;
@@ -94,7 +94,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
       log.debug("OAuth2: linkToExistingOpenIDAccounts={}",
           linkToExistingOpenIDAccounts);
       log.debug("OAuth2: domain={}", domain);
-      log.debug("OAuth2: useDomainUsersForSsh={}", useDomainUsersForSsh);
+      log.debug("OAuth2: useEmailAsUsername={}", useEmailAsUsername);
     }
   }
 
@@ -143,7 +143,7 @@ class GoogleOAuthService implements OAuthServiceProvider {
           }
         }
       }
-      if (useDomainUsersForSsh && !email.isJsonNull()) {
+      if (useEmailAsUsername && !email.isJsonNull()) {
         login = email.getAsString().split("@")[0];
       }
       return new OAuthUserInfo(id.getAsString() /*externalId*/,

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/InitOAuth.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/InitOAuth.java
@@ -26,8 +26,8 @@ class InitOAuth implements InitStep {
   static final String LINK_TO_EXISTING_OPENID_ACCOUNT =
       "link-to-existing-openid-accounts";
   static final String DOMAIN = "domain";
-  static final String USE_DOMAIN_USERS_FOR_SSH =
-      "use-domain-users-for-ssh";
+  static final String USE_EMAIL_AS_USERNAME =
+      "use-email-as-username";
 
   private final ConsoleUI ui;
   private final Section googleOAuthProviderSection;

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/InitOAuth.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/InitOAuth.java
@@ -26,6 +26,8 @@ class InitOAuth implements InitStep {
   static final String LINK_TO_EXISTING_OPENID_ACCOUNT =
       "link-to-existing-openid-accounts";
   static final String DOMAIN = "domain";
+  static final String USE_DOMAIN_USERS_FOR_SSH =
+      "use-domain-users-for-ssh";
 
   private final ConsoleUI ui;
   private final Section googleOAuthProviderSection;

--- a/src/main/resources/Documentation/config.md
+++ b/src/main/resources/Documentation/config.md
@@ -44,6 +44,18 @@ Google OAuth. The `domain` option can be added:
 plugin.gerrit-oauth-provider-google-oauth.domain = "mycollege.edu"
 ```
 
+By default the Google OAuth provider will not set a username (used for ssh) and
+the user can choose one from the web ui (needed before using ssh). It is possible
+to automatically use the user part from the google apps email. This is deactivated
+by default. To activate it, add:
+
+```
+plugin.gerrit-oauth-provider-google-oauth.use-domain-users-for-ssh = true
+```
+
+Note: the usernames are unique in gerrit. If a username already exists this will
+be ignored and the user will have to choose a different one from the web ui.
+
 (See the spec)[https://developers.google.com/identity/protocols/OpenIDConnect#hd-param]
 for more information. To protect against client-side request modification, the returned
 ID token is checked to contain a matching hd claim (which is proof the account does belong
@@ -96,7 +108,7 @@ To obtain client-id and client-secret for GitHub OAuth, go to
   `<canonical-web-uri-of-gerrit>/oauth`.
 
   ![Register new application on GitHub](images/github-1.png)
-  
+
 
 After application is registered, the page will show generated client id and
 secret.

--- a/src/main/resources/Documentation/config.md
+++ b/src/main/resources/Documentation/config.md
@@ -50,7 +50,7 @@ to automatically use the user part from the google apps email. This is deactivat
 by default. To activate it, add:
 
 ```
-plugin.gerrit-oauth-provider-google-oauth.use-domain-users-for-ssh = true
+plugin.gerrit-oauth-provider-google-oauth.use-email-as-username = true
 ```
 
 Note: the usernames are unique in gerrit. If a username already exists this will


### PR DESCRIPTION
This is disabled by default, and without enabling the config setting it will not do anything different from the current behavior (leaving the user empty so the user can choose one from the web ui). If enabled, it will use the user part from the email address to automatically set the gerrit username. 

I've seen from #39 your concern that the username might not be unique, and even though for our usecase we will use a single google auth domain (basically ensuring that each user will be unique), I've made sure that this will not blow up if someone uses it with multiple domains and non-unique users. If that happens (a username clash), then gerrit will create the user with an empty username (current default behavior), and will log something like:

```
[2015-09-18 21:00:23,913] ERROR com.google.gerrit.server.account.AccountManager : 
Cannot assign user name "blah" to account 1000002; name already in use.
```

but the user is active and functional and the user can set his own username to something else unique.