### PR TITLE
Google OAuth2: Fix double grant_type bug

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/Google2Api.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/Google2Api.java
@@ -41,7 +41,7 @@ public class Google2Api extends DefaultApi20 {
 
   @Override
   public String getAccessTokenEndpoint() {
-    return "https://accounts.google.com/o/oauth2/token?grant_type=authorization_code";
+    return "https://accounts.google.com/o/oauth2/token";
   }
 
   @Override


### PR DESCRIPTION
I believe the `Google2Api` provider has a bug when connecting to the latest version of Google OAuth2 endpoints. Google expects only a single `grant_type` to be sent, however, the `Google2Api` provider sends two `grand_type` parameters, one in the URL and one in the body.

This pull request remove the `grant_type` from the URL. An error log of the previous behavior can be found below:
```
[2016-09-27 22:32:39,494] [HTTP-833] ERROR com.google.gerrit.pgm.http.jetty.HiddenErrorHandler : Error in GET /oauth?redacted_parameters=redacted
org.scribe.exceptions.OAuthException: Cannot extract an acces token. Response was: {
  "error" : "invalid_request",
  "error_description" : "OAuth 2 parameters can only have a single value: grant_type"
}
	at com.googlesource.gerrit.plugins.oauth.Google2Api$GoogleJsonTokenExtractor.extract(Google2Api.java:163)
	at com.googlesource.gerrit.plugins.oauth.Google2Api$GoogleOAuthService.getAccessToken(Google2Api.java:112)
	at com.googlesource.gerrit.plugins.oauth.GoogleOAuthService.getAccessToken(GoogleOAuthService.java:221)
	at com.google.gerrit.httpd.auth.oauth.OAuthSession.login(OAuthSession.java:98)
	at com.google.gerrit.httpd.auth.oauth.OAuthWebFilter.doFilter(OAuthWebFilter.java:109)
...
```