### PR TITLE
Add support for tenant for Azure/office365

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/Office365Api.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/Office365Api.java
@@ -19,14 +19,21 @@ import com.github.scribejava.core.oauth2.clientauthentication.ClientAuthenticati
 import com.github.scribejava.core.oauth2.clientauthentication.RequestBodyAuthenticationScheme;
 
 public class Office365Api extends DefaultApi20 {
+
+  private final String realm;
+
+  public Office365Api(String realm) {
+    this.realm = realm;
+  }
+
   @Override
   public String getAccessTokenEndpoint() {
-    return "https://login.microsoftonline.com/organizations/oauth2/v2.0/token";
+    return "https://login.microsoftonline.com/" + realm + "/oauth2/v2.0/token";
   }
 
   @Override
   public String getAuthorizationBaseUrl() {
-    return "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize";
+    return "https://login.microsoftonline.com/" + realm + "/oauth2/v2.0/authorize";
   }
 
   @Override

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/Office365OAuthService.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/Office365OAuthService.java
@@ -62,12 +62,13 @@ class Office365OAuthService implements OAuthServiceProvider {
     PluginConfig cfg = cfgFactory.getFromGerritConfig(pluginName + CONFIG_SUFFIX);
     this.canonicalWebUrl = CharMatcher.is('/').trimTrailingFrom(urlProvider.get()) + "/";
     this.useEmailAsUsername = cfg.getBoolean(InitOAuth.USE_EMAIL_AS_USERNAME, false);
+    String realm = cfg.getString(InitOAuth.REALM, "organizations");
     this.service =
         new ServiceBuilder(cfg.getString(InitOAuth.CLIENT_ID))
             .apiSecret(cfg.getString(InitOAuth.CLIENT_SECRET))
             .callback(canonicalWebUrl + "oauth")
             .defaultScope(SCOPE)
-            .build(new Office365Api());
+            .build(new Office365Api(realm));
     if (log.isDebugEnabled()) {
       log.debug("OAuth2: canonicalWebUrl={}", canonicalWebUrl);
       log.debug("OAuth2: scope={}", SCOPE);

--- a/src/test/java/com/googlesource/gerrit/plugins/oauth/Office365ApiTest.java
+++ b/src/test/java/com/googlesource/gerrit/plugins/oauth/Office365ApiTest.java
@@ -25,7 +25,7 @@ public class Office365ApiTest {
 
   @Before
   public void setUp() {
-    api = new Office365Api();
+    api = new Office365Api("");
   }
 
   @Test


### PR DESCRIPTION
Adding the realm config parameter so you can lock the Azure oauth to a specific Azure AD controller as described here
https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow

Also this github seems to be out of date compared to https://gerrit.googlesource.com/plugins/oauth/ several commits are missing here.

