### PR TITLE
Fixed Keycloak OIDC URL and BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,7 +8,7 @@ load(
 )
 
 gerrit_plugin(
-    name = "gerrit-oauth-provider",
+    name = "oauth",
     srcs = glob(["src/main/java/**/*.java"]),
     manifest_entries = [
         "Gerrit-PluginName: gerrit-oauth-provider",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ following:
 
 ```
   git clone https://gerrit.googlesource.com/plugins/oauth gerrit-oauth-provider
-  cd gerrit-oauth-provider && bazel build gerrit-oauth-provider
+  cd gerrit-oauth-provider && bazel build oauth
 ```
 
 Install

--- a/src/main/java/com/googlesource/gerrit/plugins/oauth/KeycloakApi.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/oauth/KeycloakApi.java
@@ -22,7 +22,7 @@ import com.github.scribejava.core.oauth2.clientauthentication.RequestBodyAuthent
 
 public class KeycloakApi extends DefaultApi20 {
 
-  private static final String AUTHORIZE_URL = "%s/auth/realms/%s/protocol/openid-connect/auth";
+  private static final String AUTHORIZE_URL = "%s/realms/%s/protocol/openid-connect/auth";
 
   private final String rootUrl;
   private final String realm;
@@ -39,7 +39,7 @@ public class KeycloakApi extends DefaultApi20 {
 
   @Override
   public String getAccessTokenEndpoint() {
-    return String.format("%s/auth/realms/%s/protocol/openid-connect/token", rootUrl, realm);
+    return String.format("%s/realms/%s/protocol/openid-connect/token", rootUrl, realm);
   }
 
   @Override


### PR DESCRIPTION
The guide in BUILD did not work, so I changed the name in gerrit_plugin to 'oauth'. Then it worked.

The Keycloak URLs have changed, so I have fixed that as well. The output plugin file have been tested on the latest version of Gerrit and OIDC works fine now.